### PR TITLE
fix history: call history method instead of presence

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -85,7 +85,7 @@ class Client
      */
     public function history($channel)
     {
-        return $this->send("presence", ["channel" => $channel]);
+        return $this->send("history", ["channel" => $channel]);
     }
 
     /**


### PR DESCRIPTION
Just got a report about using wrong API method in history command, fixed! 