### PR TITLE
ENH: Cert and CA path options for Transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,31 @@ Or to create private channel sign:
 	$sign = $client->setSecret($pSecret)->generateClientToken($client, $channel);
 ```
 
+Since 1.0.3 phpcent has broadcast implementation.
+
+```php
+$client->broadcast(['example:entities', 'example:moar'], ['user_id' => 2321321, 'state' => '1']);
+```
+
+### SSL
+
 In case if your Centrifugo server has invalid SSL certificate, you can use:
 
 ```php
 \phpcent\Transport::setSafety(\phpcent\Transport::UNSAFE);
 ```
 
-Since 1.0.3  phpcent has broadcast implementation. 
+Since 1.0.5 you can use self signed certificate in safe manner:
 
 ```php
-$client->broadcast(['example:entities', 'example:moar'], ['user_id' => 2321321, 'state' => '1']);
+$client = new \phpcent\Client("https://localhost:8000");
+$client->setSecret("secret key from Centrifugo");
+$transport = new \phpcent\Transport();
+$transport->setCert("/path/to/certificate.pem");
+$client->setTransport($transport);
 ```
+
+*Note:* Certificate must match with host name in `Client` address (`localhost` in example above).
 
 Alternative clients
 ===================

--- a/Transport.php
+++ b/Transport.php
@@ -37,6 +37,7 @@ class Transport implements ITransport
         curl_setopt($ch, CURLOPT_POSTFIELDS, $postData);
 
         $response = curl_exec($ch);
+        $error = curl_error($ch);
         $headers = curl_getinfo($ch);
         curl_close($ch);
 
@@ -44,6 +45,7 @@ class Transport implements ITransport
             throw new TransportException ("Response code: "
                 . $headers["http_code"]
                 . PHP_EOL
+                . "cURL error: " . $error . PHP_EOL
                 . "Body: "
                 . $response
             );

--- a/Transport.php
+++ b/Transport.php
@@ -16,6 +16,17 @@ class Transport implements ITransport
     protected static $safety = self::SAFE;
 
     /**
+     * @var string Certificate file name
+     * @since 1.0.5
+     */
+    private $cert;
+    /**
+     * @var string Directory containing CA certificates
+     * @since 1.0.5
+     */
+    private $caPath;
+
+    /**
      * @param mixed $safety
      */
     public static function setSafety($safety)
@@ -29,8 +40,19 @@ class Transport implements ITransport
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POST, 1);
 
-        if (self::$safety === Transport::UNSAFE) {
+        if (self::$safety === self::UNSAFE) {
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+        } elseif (self::$safety === self::SAFE) {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+
+            if (null !== $this->cert) {
+                curl_setopt($ch, CURLOPT_CAINFO, $this->cert);
+            }
+            if (null !== $this->caPath) {
+                curl_setopt($ch, CURLOPT_CAPATH, $this->caPath);
+            }
         }
 
         $postData = http_build_query($data, '', '&');
@@ -54,5 +76,41 @@ class Transport implements ITransport
         $answer = json_decode($response, true);
 
         return $answer;
+    }
+
+    /**
+     * @return string|null
+     * @since 1.0.5
+     */
+    public function getCert()
+    {
+        return $this->cert;
+    }
+
+    /**
+     * @param string|null $cert
+     * @since 1.0.5
+     */
+    public function setCert($cert)
+    {
+        $this->cert = $cert;
+    }
+
+    /**
+     * @return string|null
+     * @since 1.0.5
+     */
+    public function getCAPath()
+    {
+        return $this->caPath;
+    }
+
+    /**
+     * @param string|null $caPath
+     * @since 1.0.5
+     */
+    public function setCAPath($caPath)
+    {
+        $this->caPath = $caPath;
     }
 }


### PR DESCRIPTION
I guess next version will be 1.0.5, so I add `@since 1.0.5`. But I didn't change `version` in `composer.json` and didn't add tags as it is out of specific PR scope.