### PR TITLE
Update Client.php

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -310,7 +310,7 @@ class Client
     public function generatePrivateChannelToken($client, $channel, $exp = 0, $info = [])
     {
         $header = ['typ' => 'JWT', 'alg' => 'HS256'];
-        $payload = ['channel' => $channel, 'client' => $client];
+        $payload = ['channel' => (string)$channel, 'client' => (string)$client];
         if (!empty($info)) {
             $payload['info'] = $info;
         }


### PR DESCRIPTION
Fix for converting $channel / $client to String (if it defined as number) as  it is expected by Centrifuge server