### PR TITLE
Correct `_json_last_error_msg()` scoping.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -352,7 +352,7 @@ class Client
         $response = \json_decode($this->request($method, $params), $this->useAssoc);
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw new \Exception(
-                'json_decode error: ' . _json_last_error_msg()
+                'json_decode error: ' . $this->_json_last_error_msg()
             );
         }
         return $response;


### PR DESCRIPTION
Before this change, errors returned from `\json_decode()` would improperly cause a PHP Error:

```
Error: Call to undefined function phpcent\_json_last_error_msg() 
  in vendor/centrifugal/phpcent/src/Client.php:355
Stack trace:
#0 vendor/centrifugal/phpcent/src/Client.php(131): phpcent\Client->send('publish', Array)
#1 my/calling/context.php(x): phpcent\Client->publish('namespace:channel', Array)
```