### PR TITLE
Fix for info() failing with the new HTTP API format. Added test.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -432,7 +432,7 @@ class Client
         curl_setopt($ch, CURLOPT_HEADER, 0);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POST, true);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, \json_encode($params));
+        curl_setopt($ch, CURLOPT_POSTFIELDS, \json_encode((object)$params));
         curl_setopt($ch, CURLOPT_HTTPHEADER, $this->getHeaders());
         curl_setopt($ch, CURLOPT_URL, $this->getUrl($method));
         $data = curl_exec($ch);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -70,4 +70,11 @@ class ClientTest extends PHPUnit\Framework\TestCase
         $client = new \phpcent\Client("http://localhost:9000/api");
         $res = $client->publish('channel', ["message" => "Hello World"]);
     }
+
+    public function testInfo()
+    {
+        $res = $this->client->info();
+        $this->assertNotNull($res);
+        $this->assertTrue(is_array($res->result->nodes));
+    }
 }


### PR DESCRIPTION
Changes:
```php
curl_setopt($ch, CURLOPT_POSTFIELDS, \json_encode($params));
```

to 
```php
curl_setopt($ch, CURLOPT_POSTFIELDS, \json_encode((object)$params));
```

so that an empty array gets encoded as `{}` instead of `[]`, allowing parameter-less API calls (like `info()`) to produce a valid JSON payload.

Fixes #64