### PR TITLE
fix E_DEPRECATED:Function curl_close() is deprecated since 8.5, as it…

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -449,7 +449,9 @@ class Client
         $data = curl_exec($ch);
         $error = curl_error($ch);
         $headers = curl_getinfo($ch);
-        curl_close($ch);
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
         if (empty($headers["http_code"]) || ($headers["http_code"] != 200)) {
             throw new \Exception(
                 "Response code: "


### PR DESCRIPTION
… has no effect since PHP 8.0